### PR TITLE
fix: Switch to deploy from GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,11 +35,7 @@ jobs:
       - name: Render Quarto Project
         shell: bash
         run: |
-          echo -e "project:\n  output-dir: _site" > _quarto.yml
-          # Render to all formats via for loop to avoid LaTeX error "pdf/beamer" formats
-          for format in html typst pdf docx revealjs beamer pptx; do
-            quarto render --to ${format}
-          done
+          quarto render --to html --output index.html
       
       - uses: actions/configure-pages@v5
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Render Quarto Project
         shell: bash
         run: |
-          quarto render --to html --output index.html
+          quarto render example.qmd --to html --output index.html --output-dir _site
       
       - uses: actions/configure-pages@v5
 


### PR DESCRIPTION
Switches the deployment process to use GitHub Actions instead of the previous method. This change simplifies the deployment workflow and ensures consistent and reliable deployments.

Fixes #12