### PR TITLE
fix(badge): warn on unknown keys, escape attributes, validate inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+## 2.5.0 (2026-05-28)
+
+### New Features
+
+- feat: Add `icon` configuration option for a Bootstrap icon prefix shown before the badge value.
+- feat: Add `target` configuration option for the link target attribute, automatically setting `rel="noopener noreferrer"` for `_blank`.
+- feat: Add `title` configuration option for a hover tooltip, with `{{value}}` placeholder support.
+- feat: Validate `colour` against CSS named colours, hex, `rgb`/`rgba`, `hsl`/`hsla`, `hwb`, `lab`, `lch`, `oklab`, `oklch`, and `color()` values; invalid values are warned and ignored.
+- feat: Validate `href` (after `{{value}}` substitution) and reject malformed or disallowed-scheme URLs with a warning.
+- feat: Support per-document badge overrides via the `badge-overrides` metadata key; entries override matching `key` values from the base configuration and new keys are appended.
+
+### Bug Fixes
+
+- fix: Warn when the badge shortcode is invoked with a key that is not configured (previously rendered an empty element silently).
+- fix: HTML-escape the badge value, `href` attribute, `{{value}}` substitution result, and `class`/`title` attributes to prevent attribute injection.
+
+### Refactoring
+
+- refactor: Synchronise shared modules (`string.lua`, `logging.lua`, `metadata.lua`, `pandoc-helpers.lua`) with the canonical source and add `colour.lua` for colour validation.
+
+### Documentation
+
+- docs: Document new configuration options, validation behaviour, and document-level overrides in README and example.
+- docs: Extend `_schema.yml` with the new properties and the `badge-overrides` key.
+
 ## 2.4.1 (2026-04-15)
 
 ### Refactoring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 2.5.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add `icon` configuration option for a Bootstrap icon prefix shown before the badge value.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-badge
+quarto add mcanouil/quarto-badge@2.4.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-badge@2.4.1
+quarto add mcanouil/quarto-badge
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -47,8 +47,31 @@ Each badge configuration supports the following properties:
 
 - **`key`** (required): The identifier used in the shortcode to reference this badge configuration.
 - **`colour`** or **`color`** (optional): A CSS colour value (e.g., `firebrick`, `#ff0000`, `rgb(255, 0, 0)`).
+  Invalid values are reported via a `quarto.log.warning` call and ignored.
 - **`class`** (optional): CSS class(es) to apply to the badge (e.g., Bootstrap classes like `bg-danger`, `bg-warning`).
-- **`href`** (optional): URL to link the badge to. Use `{{value}}` as a placeholder to insert the badge value into the URL.
+- **`href`** (optional): URL to link the badge to.
+  Use `{{value}}` as a placeholder to insert the badge value into the URL.
+  Disallowed schemes (such as `javascript:`) are reported via a warning and ignored.
+- **`target`** (optional): Link target attribute used together with `href`.
+  Allowed values are `_self`, `_blank`, `_parent`, and `_top`.
+  When set to `_blank`, the link automatically receives `rel="noopener noreferrer"`.
+- **`title`** (optional): Tooltip text shown on hover.
+  The `{{value}}` placeholder is replaced with the badge value.
+- **`icon`** (optional): Bootstrap icon name (without the `bi-` prefix) shown before the badge value.
+
+### Document-Level Overrides
+
+Project-level badges defined in `_quarto.yml` can be overridden on a per-document basis using the `badge-overrides` key in the document front matter.
+Entries are matched by `key`; matching keys are replaced and new keys are appended.
+
+```yaml
+badge-overrides:
+  - key: experimental
+    colour: hotpink
+  - key: doc-only
+    colour: teal
+    icon: stars
+```
 
 ### Examples
 
@@ -94,6 +117,23 @@ extensions:
 
 This creates a badge linking to `https://github.com/user/repo/releases/tag/v1.5.0`.
 
+#### Badge with Icon, Tooltip, and Link Target
+
+```yaml
+extensions:
+  badge:
+    - key: download
+      colour: dodgerblue
+      icon: download
+      href: https://github.com/user/repo/releases/tag/v{{value}}
+      target: _blank
+      title: "Download release {{value}} in a new tab"
+```
+
+```markdown
+{{< badge download 1.5.0 >}}
+```
+
 ### Using Badges in Headers
 
 Badges can be used in section headers to indicate feature status or version information:
@@ -109,6 +149,17 @@ Badges can be used in section headers to indicate feature status or version info
 > [!CAUTION]
 > The `href` attribute is optional and currently breaks the table of contents links when used in headers.
 
+## Validation and Warnings
+
+The extension emits warnings via `quarto.log.warning` (each unique value is only warned about once per render) in the following cases:
+
+- The shortcode is invoked with a key that is not defined in metadata.
+- A configured `colour` value is not a recognised CSS colour, hex, `rgb`/`rgba`, `hsl`/`hsla`, `hwb`, `lab`, `lch`, `oklab`, `oklch`, or `color()` value.
+- A configured `href` (after `{{value}}` substitution) is not a plausible URL or uses a disallowed scheme.
+- A configured `target` is not one of `_self`, `_blank`, `_parent`, or `_top`.
+
+In all of these cases the offending attribute is dropped rather than silently emitted, and the badge still renders (or is replaced by an empty inline when the key is unknown).
+
 ## Example
 
 Here is the source code for a minimal example: [example.qmd](example.qmd).
@@ -120,4 +171,5 @@ Output of `example.qmd`:
 ## Notes
 
 - The extension only works with HTML output formats.
+- All user-supplied values are HTML-escaped before they are written to the document.
 - The deprecated top-level `badge` configuration (instead of `extensions.badge`) is still supported but will show a warning.

--- a/_extensions/badge/_extension.yml
+++ b/_extensions/badge/_extension.yml
@@ -1,6 +1,6 @@
 title: badge
 author: Mickaël Canouil
-version: 2.4.1
+version: 2.5.0
 quarto-required: ">=1.6.0"
 contributes:
   shortcodes:

--- a/_extensions/badge/_extension.yml
+++ b/_extensions/badge/_extension.yml
@@ -1,6 +1,6 @@
 title: badge
 author: Mickaël Canouil
-version: 2.5.0
+version: 2.4.1
 quarto-required: ">=1.6.0"
 contributes:
   shortcodes:

--- a/_extensions/badge/_modules/colour.lua
+++ b/_extensions/badge/_modules/colour.lua
@@ -1,0 +1,369 @@
+--- MC Colour - Colour conversion utilities for Quarto Lua filters and shortcodes
+--- @module "colour"
+--- @license MIT
+--- @copyright 2026 Mickaël Canouil
+--- @author Mickaël Canouil
+--- @version 1.0.0
+
+local M = {}
+
+-- ============================================================================
+-- CSS NAMED COLOURS
+-- ============================================================================
+
+--- CSS named colours lookup table.
+--- Maps lowercase colour names to uppercase 6-character hex codes.
+--- Contains all 148 standard CSS named colours.
+--- @type table<string, string>
+local CSS_NAMED_COLOURS = {
+  aliceblue = '#F0F8FF',
+  antiquewhite = '#FAEBD7',
+  aqua = '#00FFFF',
+  aquamarine = '#7FFFD4',
+  azure = '#F0FFFF',
+  beige = '#F5F5DC',
+  bisque = '#FFE4C4',
+  black = '#000000',
+  blanchedalmond = '#FFEBCD',
+  blue = '#0000FF',
+  blueviolet = '#8A2BE2',
+  brown = '#A52A2A',
+  burlywood = '#DEB887',
+  cadetblue = '#5F9EA0',
+  chartreuse = '#7FFF00',
+  chocolate = '#D2691E',
+  coral = '#FF7F50',
+  cornflowerblue = '#6495ED',
+  cornsilk = '#FFF8DC',
+  crimson = '#DC143C',
+  cyan = '#00FFFF',
+  darkblue = '#00008B',
+  darkcyan = '#008B8B',
+  darkgoldenrod = '#B8860B',
+  darkgray = '#A9A9A9',
+  darkgreen = '#006400',
+  darkgrey = '#A9A9A9',
+  darkkhaki = '#BDB76B',
+  darkmagenta = '#8B008B',
+  darkolivegreen = '#556B2F',
+  darkorange = '#FF8C00',
+  darkorchid = '#9932CC',
+  darkred = '#8B0000',
+  darksalmon = '#E9967A',
+  darkseagreen = '#8FBC8F',
+  darkslateblue = '#483D8B',
+  darkslategray = '#2F4F4F',
+  darkslategrey = '#2F4F4F',
+  darkturquoise = '#00CED1',
+  darkviolet = '#9400D3',
+  deeppink = '#FF1493',
+  deepskyblue = '#00BFFF',
+  dimgray = '#696969',
+  dimgrey = '#696969',
+  dodgerblue = '#1E90FF',
+  firebrick = '#B22222',
+  floralwhite = '#FFFAF0',
+  forestgreen = '#228B22',
+  fuchsia = '#FF00FF',
+  gainsboro = '#DCDCDC',
+  ghostwhite = '#F8F8FF',
+  gold = '#FFD700',
+  goldenrod = '#DAA520',
+  gray = '#808080',
+  green = '#008000',
+  greenyellow = '#ADFF2F',
+  grey = '#808080',
+  honeydew = '#F0FFF0',
+  hotpink = '#FF69B4',
+  indianred = '#CD5C5C',
+  indigo = '#4B0082',
+  ivory = '#FFFFF0',
+  khaki = '#F0E68C',
+  lavender = '#E6E6FA',
+  lavenderblush = '#FFF0F5',
+  lawngreen = '#7CFC00',
+  lemonchiffon = '#FFFACD',
+  lightblue = '#ADD8E6',
+  lightcoral = '#F08080',
+  lightcyan = '#E0FFFF',
+  lightgoldenrodyellow = '#FAFAD2',
+  lightgray = '#D3D3D3',
+  lightgreen = '#90EE90',
+  lightgrey = '#D3D3D3',
+  lightpink = '#FFB6C1',
+  lightsalmon = '#FFA07A',
+  lightseagreen = '#20B2AA',
+  lightskyblue = '#87CEFA',
+  lightslategray = '#778899',
+  lightslategrey = '#778899',
+  lightsteelblue = '#B0C4DE',
+  lightyellow = '#FFFFE0',
+  lime = '#00FF00',
+  limegreen = '#32CD32',
+  linen = '#FAF0E6',
+  magenta = '#FF00FF',
+  maroon = '#800000',
+  mediumaquamarine = '#66CDAA',
+  mediumblue = '#0000CD',
+  mediumorchid = '#BA55D3',
+  mediumpurple = '#9370DB',
+  mediumseagreen = '#3CB371',
+  mediumslateblue = '#7B68EE',
+  mediumspringgreen = '#00FA9A',
+  mediumturquoise = '#48D1CC',
+  mediumvioletred = '#C71585',
+  midnightblue = '#191970',
+  mintcream = '#F5FFFA',
+  mistyrose = '#FFE4E1',
+  moccasin = '#FFE4B5',
+  navajowhite = '#FFDEAD',
+  navy = '#000080',
+  oldlace = '#FDF5E6',
+  olive = '#808000',
+  olivedrab = '#6B8E23',
+  orange = '#FFA500',
+  orangered = '#FF4500',
+  orchid = '#DA70D6',
+  palegoldenrod = '#EEE8AA',
+  palegreen = '#98FB98',
+  paleturquoise = '#AFEEEE',
+  palevioletred = '#DB7093',
+  papayawhip = '#FFEFD5',
+  peachpuff = '#FFDAB9',
+  peru = '#CD853F',
+  pink = '#FFC0CB',
+  plum = '#DDA0DD',
+  powderblue = '#B0E0E6',
+  purple = '#800080',
+  rebeccapurple = '#663399',
+  red = '#FF0000',
+  rosybrown = '#BC8F8F',
+  royalblue = '#4169E1',
+  saddlebrown = '#8B4513',
+  salmon = '#FA8072',
+  sandybrown = '#F4A460',
+  seagreen = '#2E8B57',
+  seashell = '#FFF5EE',
+  sienna = '#A0522D',
+  silver = '#C0C0C0',
+  skyblue = '#87CEEB',
+  slateblue = '#6A5ACD',
+  slategray = '#708090',
+  slategrey = '#708090',
+  snow = '#FFFAFA',
+  springgreen = '#00FF7F',
+  steelblue = '#4682B4',
+  tan = '#D2B48C',
+  teal = '#008080',
+  thistle = '#D8BFD8',
+  tomato = '#FF6347',
+  turquoise = '#40E0D0',
+  violet = '#EE82EE',
+  wheat = '#F5DEB3',
+  white = '#FFFFFF',
+  whitesmoke = '#F5F5F5',
+  yellow = '#FFFF00',
+  yellowgreen = '#9ACD32'
+}
+
+--- Check if a value is a CSS named colour.
+--- Performs case-insensitive matching against the 148 standard CSS named colours.
+--- @param value string|nil The colour value to check
+--- @return boolean True if the value is a recognised CSS named colour
+--- @usage local result = M.is_named_colour('rebeccapurple') -- returns true
+function M.is_named_colour(value)
+  if not value then return false end
+  return CSS_NAMED_COLOURS[value:lower()] ~= nil
+end
+
+-- ============================================================================
+-- COLOUR CONVERSION UTILITIES
+-- ============================================================================
+
+--- Expand 3-character hex colour to 6-character format.
+--- @param hex string Hex colour code (either #123 or #123456 format)
+--- @return string 6-character hex colour code (e.g., #123 becomes #112233)
+function M.expand_hex_colour(hex)
+  if string.len(hex) == 4 then
+    return (string.gsub(hex, '#(%x)(%x)(%x)', '#%1%1%2%2%3%3'))
+  end
+  return hex
+end
+
+--- Convert RGB colour notation to HTML hex format.
+--- @param rgb string RGB colour string in format "rgb(r, g, b)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.RGB_to_HTML(rgb)
+  local r, g, b = rgb:match('rgb%((%d+)%s*,%s*(%d+)%s*,%s*(%d+)%s*%)')
+  r = tonumber(r)
+  g = tonumber(g)
+  b = tonumber(b)
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Convert RGB percentage notation to HTML hex format.
+--- @param rgb string RGB colour string in format "rgb(r%, g%, b%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.RGBPercent_to_HTML(rgb)
+  local r, g, b = rgb:match('rgb%((%d+)%s*%%%s*,%s*(%d+)%s*%%%s*,%s*(%d+)%s*%%%s*%)')
+  r = math.floor(tonumber(r) * 255 / 100 + 0.5)
+  g = math.floor(tonumber(g) * 255 / 100 + 0.5)
+  b = math.floor(tonumber(b) * 255 / 100 + 0.5)
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Helper function to convert hue to RGB component.
+--- @param p number
+--- @param q number
+--- @param t number
+--- @return number RGB component value
+function M.hue_to_rgb(p, q, t)
+  if t < 0 then t = t + 1 end
+  if t > 1 then t = t - 1 end
+  if t < 1 / 6 then return p + (q - p) * 6 * t end
+  if t < 1 / 2 then return q end
+  if t < 2 / 3 then return p + (q - p) * (2 / 3 - t) * 6 end
+  return p
+end
+
+--- Convert HSL colour notation to HTML hex format.
+--- @param hsl string HSL colour string in format "hsl(h, s%, l%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.HSL_to_HTML(hsl)
+  local h, s, l = hsl:match('hsl%((%d+)%s*,%s*(%d+)%%%s*,%s*(%d+)%%%s*%)')
+  h = tonumber(h) / 360
+  s = tonumber(s) / 100
+  l = tonumber(l) / 100
+
+  local r, g, b
+  if s == 0 then
+    r, g, b = l, l, l
+  else
+    local q = l < 0.5 and l * (1 + s) or l + s - l * s
+    local p = 2 * l - q
+    r = M.hue_to_rgb(p, q, h + 1 / 3)
+    g = M.hue_to_rgb(p, q, h)
+    b = M.hue_to_rgb(p, q, h - 1 / 3)
+  end
+
+  r = math.floor(r * 255 + 0.5)
+  g = math.floor(g * 255 + 0.5)
+  b = math.floor(b * 255 + 0.5)
+
+  return string.upper(string.format('#%02x%02x%02x', r, g, b))
+end
+
+--- Convert HWB colour notation to HTML hex format.
+--- @param hwb string HWB colour string in format "hwb(h w% b%)"
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.HWB_to_HTML(hwb)
+  local h, w, b = hwb:match('hwb%((%d+)%s+(%d+)%%%s+(%d+)%%%s*%)')
+  h = tonumber(h)
+  w = tonumber(w) / 100
+  b = tonumber(b) / 100
+
+  local sum = w + b
+  if sum > 1 then
+    w = w / sum
+    b = b / sum
+  end
+
+  h = h / 360
+
+  local r, g, b_colour
+  local q = 1
+  local p = 0
+  r = M.hue_to_rgb(p, q, h + 1 / 3)
+  g = M.hue_to_rgb(p, q, h)
+  b_colour = M.hue_to_rgb(p, q, h - 1 / 3)
+
+  r = r * (1 - w - b) + w
+  g = g * (1 - w - b) + w
+  b_colour = b_colour * (1 - w - b) + w
+
+  r = math.floor(r * 255 + 0.5)
+  g = math.floor(g * 255 + 0.5)
+  b_colour = math.floor(b_colour * 255 + 0.5)
+
+  return string.upper(string.format('#%02x%02x%02x', r, g, b_colour))
+end
+
+--- Convert a CSS named colour to HTML hex format.
+--- @param name string CSS colour name (case-insensitive)
+--- @return string HTML hex colour code in uppercase format (e.g., "#FF0000")
+function M.named_to_HTML(name)
+  local hex = CSS_NAMED_COLOURS[name:lower()]
+  if not hex then
+    error('Unknown CSS named colour: ' .. tostring(name))
+  end
+  return hex
+end
+
+--- Convert a colour code to HTML format based on its format type.
+--- @param code string The colour code to convert
+--- @param format string The colour format (e.g., "hwb", "hsl", "rgb", "rgb_percent", "hex", "named")
+--- @return string HTML hex colour code
+function M.to_html(code, format)
+  local converters = {
+    hwb = M.HWB_to_HTML,
+    hsl = M.HSL_to_HTML,
+    rgb = M.RGB_to_HTML,
+    rgb_percent = M.RGBPercent_to_HTML,
+    hex = M.expand_hex_colour,
+    hex3 = M.expand_hex_colour,
+    hex6 = M.expand_hex_colour,
+    named = M.named_to_HTML
+  }
+
+  local converter = converters[format]
+  if converter then
+    return converter(code)
+  else
+    error('Unsupported colour format: ' .. format)
+  end
+end
+
+-- ============================================================================
+-- COLOUR ATTRIBUTE UTILITIES
+-- ============================================================================
+
+--- Get colour value from attributes table, accepting both British and American spellings.
+--- Checks for 'colour' first (British, primary), then falls back to 'color' (American).
+--- @param attrs table Attributes table (kwargs or element.attributes)
+--- @param default string|nil Default value if neither spelling is found
+--- @return string|nil Colour value or default
+--- @usage local colour = M.get_colour(kwargs, 'info')
+function M.get_colour(attrs, default)
+  if attrs == nil then
+    return default
+  end
+  local value = attrs.colour or attrs.color
+  if value == nil then
+    return default
+  end
+  local str_value = pandoc.utils.stringify(value)
+  if str_value == '' then
+    return default
+  end
+  return str_value
+end
+
+--- Check if a colour value is a custom colour (hex, rgb, hsl, hwb, etc.).
+--- Used to determine whether to apply a semantic class or inline style.
+--- Named CSS colours are not custom colours; they are standard/semantic values.
+--- @param colour string|nil The colour value to check
+--- @return boolean True if it's a custom colour value
+--- @usage local is_custom = M.is_custom_colour('#ff6600') -- returns true
+--- @usage local is_custom = M.is_custom_colour('red') -- returns false
+function M.is_custom_colour(colour)
+  if not colour then return false end
+  if M.is_named_colour(colour) then return false end
+  local lower = colour:lower()
+  return lower:match('^#') or lower:match('^rgb') or lower:match('^hsl') or lower:match('^hwb')
+end
+
+-- ============================================================================
+-- MODULE EXPORT
+-- ============================================================================
+
+return M

--- a/_extensions/badge/_modules/logging.lua
+++ b/_extensions/badge/_modules/logging.lua
@@ -1,5 +1,5 @@
 --- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
---- @module logging
+--- @module "logging"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/badge/_modules/metadata.lua
+++ b/_extensions/badge/_modules/metadata.lua
@@ -1,5 +1,5 @@
 --- MC Metadata - Extension configuration and metadata access for Quarto Lua filters and shortcodes
---- @module metadata
+--- @module "metadata"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/badge/_modules/pandoc-helpers.lua
+++ b/_extensions/badge/_modules/pandoc-helpers.lua
@@ -1,5 +1,5 @@
 --- MC Pandoc Helpers - Pandoc element construction and format detection for Quarto Lua filters and shortcodes
---- @module pandoc_helpers
+--- @module "pandoc_helpers"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/badge/_modules/string.lua
+++ b/_extensions/badge/_modules/string.lua
@@ -1,5 +1,5 @@
 --- MC String - String manipulation and escaping for Quarto Lua filters and shortcodes
---- @module string
+--- @module "string"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/badge/_schema.yml
+++ b/_extensions/badge/_schema.yml
@@ -19,7 +19,7 @@ options:
           description: "CSS class to apply to the badge element."
         colour:
           type: string
-          description: "Background colour for the badge (hex or colour name)."
+          description: "Background colour for the badge (CSS named colour, hex, rgb/rgba, hsl/hsla, or hwb value)."
           aliases:
             - color
           completion:
@@ -27,6 +27,58 @@ options:
         href:
           type: string
           description: "URL to link the badge to. Use '{{value}}' as a placeholder for the badge value."
+        target:
+          type: string
+          description: "Link target attribute when 'href' is set. Allowed values are _self, _blank, _parent, _top."
+          enum:
+            - _self
+            - _blank
+            - _parent
+            - _top
+        title:
+          type: string
+          description: "Tooltip text shown on hover. The '{{value}}' placeholder is replaced with the badge value."
+        icon:
+          type: string
+          description: "Optional Bootstrap icon name (without the 'bi-' prefix) prepended before the badge value."
+  badge-overrides:
+    type: array
+    min-items: 1
+    description: "Document-level overrides for badge configurations defined at project level. Entries are matched by 'key'; matching keys are replaced, new keys are appended."
+    items:
+      type: object
+      properties:
+        key:
+          type: string
+          required: true
+          description: "Badge key to override or define."
+        class:
+          type: string
+          description: "CSS class to apply to the badge element."
+        colour:
+          type: string
+          description: "Background colour for the badge."
+          aliases:
+            - color
+          completion:
+            type: color
+        href:
+          type: string
+          description: "URL to link the badge to. Use '{{value}}' as a placeholder for the badge value."
+        target:
+          type: string
+          description: "Link target attribute."
+          enum:
+            - _self
+            - _blank
+            - _parent
+            - _top
+        title:
+          type: string
+          description: "Tooltip text shown on hover."
+        icon:
+          type: string
+          description: "Optional Bootstrap icon name (without the 'bi-' prefix)."
 
 # Per-shortcode schemas.
 # Describes positional arguments for {{< badge >}}.

--- a/_extensions/badge/badge.lua
+++ b/_extensions/badge/badge.lua
@@ -1,4 +1,4 @@
---- @module badge
+--- @module "badge"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil
@@ -10,24 +10,284 @@ local EXTENSION_NAME = 'badge'
 local str = require(quarto.utils.resolve_path('_modules/string.lua'):gsub('%.lua$', ''))
 local meta_mod = require(quarto.utils.resolve_path('_modules/metadata.lua'):gsub('%.lua$', ''))
 local pdoc = require(quarto.utils.resolve_path('_modules/pandoc-helpers.lua'):gsub('%.lua$', ''))
+local log = require(quarto.utils.resolve_path('_modules/logging.lua'):gsub('%.lua$', ''))
+local colour_mod = require(quarto.utils.resolve_path('_modules/colour.lua'):gsub('%.lua$', ''))
 
---- Flag to track if deprecation warning has been shown
+--- Flag to track if deprecation warning has been shown.
 --- @type boolean
 local deprecation_warning_shown = false
 
+--- Per-render cache of warned unknown badge keys.
+--- Prevents repeated warnings for the same key in one document.
+--- @type table<string, boolean>
+local warned_unknown_keys = {}
+
+--- Per-render cache of warned invalid colour values.
+--- @type table<string, boolean>
+local warned_invalid_colours = {}
+
+--- Per-render cache of warned invalid URLs.
+--- @type table<string, boolean>
+local warned_invalid_urls = {}
+
+--- Allowed link target values per the HTML specification.
+--- @type table<string, boolean>
+local ALLOWED_TARGETS = {
+  ['_self'] = true,
+  ['_blank'] = true,
+  ['_parent'] = true,
+  ['_top'] = true
+}
+
+--- Check whether a value looks like a syntactically plausible URL.
+--- Accepts absolute URLs (`scheme://...`), root-relative (`/...`), hash (`#...`),
+--- mailto/tel schemes, and relative paths. Rejects whitespace and obvious
+--- control characters.
+--- @param url string The URL to validate
+--- @return boolean True when the URL is plausibly well-formed
+local function is_plausible_url(url)
+  if str.is_empty(url) then return false end
+  if url:find('%s') then return false end
+  if url:find('[%c]') then return false end
+  if url:match('^https?://') then return true end
+  if url:match('^mailto:') then return true end
+  if url:match('^tel:') then return true end
+  if url:match('^ftp://') then return true end
+  if url:match('^/') then return true end
+  if url:match('^#') then return true end
+  if url:match('^%?') then return true end
+  if url:match('^[%w%._/%-]+$') then return true end
+  return false
+end
+
+--- Check whether a colour value is acceptable for CSS background-color.
+--- Accepts CSS named colours, hex (3/4/6/8), and the functional rgb/rgba/hsl/hsla/hwb/lab/lch/oklab/oklch/color forms.
+--- @param value string The colour to validate
+--- @return boolean True when the colour is recognised
+local function is_valid_colour(value)
+  if str.is_empty(value) then return false end
+  local lowered = value:lower():match('^%s*(.-)%s*$')
+  if lowered == 'transparent' or lowered == 'currentcolor' or lowered == 'inherit' then
+    return true
+  end
+  if colour_mod.is_named_colour(lowered) then return true end
+  if lowered:match('^#%x%x%x%x?%x?%x?%x?%x?$') and (#lowered == 4 or #lowered == 5 or #lowered == 7 or #lowered == 9) then
+    return true
+  end
+  if lowered:match('^rgba?%(.-%)$') then return true end
+  if lowered:match('^hsla?%(.-%)$') then return true end
+  if lowered:match('^hwb%(.-%)$') then return true end
+  if lowered:match('^lab%(.-%)$') then return true end
+  if lowered:match('^lch%(.-%)$') then return true end
+  if lowered:match('^oklab%(.-%)$') then return true end
+  if lowered:match('^oklch%(.-%)$') then return true end
+  if lowered:match('^color%(.-%)$') then return true end
+  return false
+end
+
+--- Load base badge configurations from document metadata, preferring the
+--- scoped `extensions.badge` table and falling back to the deprecated
+--- top-level `badge` key.
+--- @param meta table Document metadata
+--- @return table|nil Array of base badge configurations
+local function load_base_badges(meta)
+  local from_extension = meta_mod.get_extension_config(meta, EXTENSION_NAME)
+  if from_extension then return from_extension end
+
+  local from_deprecated
+  from_deprecated, deprecation_warning_shown = meta_mod.check_deprecated_config(
+    meta,
+    EXTENSION_NAME,
+    nil,
+    deprecation_warning_shown
+  )
+  return from_deprecated
+end
+
+--- Merge document-level badge overrides into base configurations.
+--- Overrides are matched by `key`; existing fields are replaced and new keys
+--- are appended. Honoured override sources, in order of precedence:
+---   1. `badge-overrides` (top-level).
+---   2. `extensions.badge-overrides`.
+--- @param base table|nil Array of base badge configurations
+--- @param meta table Document metadata
+--- @return table Array of effective badge configurations
+local function apply_overrides(base, meta)
+  local result = {}
+  if base then
+    for _, entry in ipairs(base) do
+      table.insert(result, entry)
+    end
+  end
+
+  local overrides = meta['badge-overrides']
+  if not overrides and meta.extensions then
+    overrides = meta.extensions['badge-overrides']
+  end
+  if not overrides then return result end
+
+  for _, override in ipairs(overrides) do
+    local override_key = str.stringify(override['key'])
+    if not str.is_empty(override_key) then
+      local replaced = false
+      for index, entry in ipairs(result) do
+        if str.stringify(entry['key']) == override_key then
+          result[index] = override
+          replaced = true
+          break
+        end
+      end
+      if not replaced then
+        table.insert(result, override)
+      end
+    end
+  end
+
+  return result
+end
+
+--- Find the badge configuration matching the requested key.
+--- @param badge_configs table Array of badge configurations
+--- @param badge_key string Requested badge key
+--- @return table|nil Matching configuration
+local function find_badge_config(badge_configs, badge_key)
+  for _, badge_config in ipairs(badge_configs) do
+    if str.stringify(badge_config['key']) == badge_key then
+      return badge_config
+    end
+  end
+  return nil
+end
+
+--- Substitute the `{{value}}` placeholder in a URL template.
+--- @param template string URL template
+--- @param value string Raw badge value
+--- @return string URL with the placeholder replaced
+local function substitute_value(template, value)
+  if not template:find('{{value}}', 1, true) then
+    return template
+  end
+  --- Escape pattern replacement specials so % in the value is not treated
+  --- as a back-reference by gsub.
+  local replacement = value:gsub('%%', '%%%%')
+  local replaced = template:gsub('{{value}}', replacement)
+  return replaced
+end
+
+--- Build the HTML for the badge content, escaping all user-supplied values.
+--- @param badge_config table Resolved badge configuration
+--- @param badge_value string Raw badge value to display
+--- @return string HTML markup for the badge
+local function build_badge_html(badge_config, badge_value)
+  --- @type string Optional CSS class list from configuration
+  local css_class = ''
+  if not str.is_empty(badge_config['class']) then
+    css_class = str.stringify(badge_config['class'])
+  end
+
+  --- @type string Optional icon name (Bootstrap icons) prepended to value
+  local icon_html = ''
+  if not str.is_empty(badge_config['icon']) then
+    local icon_name = str.stringify(badge_config['icon'])
+    icon_html = '<i class="bi bi-' .. str.escape_attribute(icon_name) ..
+      '" aria-hidden="true"></i> '
+  end
+
+  --- @type string Escaped badge value for safe HTML insertion
+  local escaped_value = str.escape_html(badge_value)
+  --- @type string Full inner HTML for the badge body
+  local inner_html = icon_html .. escaped_value
+
+  -- Optional href: wrap inner content in an anchor.
+  if not str.is_empty(badge_config['href']) then
+    local href_template = str.stringify(badge_config['href'])
+    local resolved_href = substitute_value(href_template, badge_value)
+    if not is_plausible_url(resolved_href) then
+      if not warned_invalid_urls[resolved_href] then
+        log.log_warning(
+          EXTENSION_NAME,
+          'Ignoring malformed href "' .. resolved_href ..
+          '" for badge key "' .. str.stringify(badge_config['key']) .. '".'
+        )
+        warned_invalid_urls[resolved_href] = true
+      end
+    else
+      local anchor_attrs = 'href="' .. str.escape_attribute(resolved_href) ..
+        '" class="quarto-badge-href"'
+
+      if not str.is_empty(badge_config['target']) then
+        local target_value = str.stringify(badge_config['target'])
+        if ALLOWED_TARGETS[target_value] then
+          anchor_attrs = anchor_attrs ..
+            ' target="' .. str.escape_attribute(target_value) .. '"'
+          if target_value == '_blank' then
+            anchor_attrs = anchor_attrs .. ' rel="noopener noreferrer"'
+          end
+        else
+          log.log_warning(
+            EXTENSION_NAME,
+            'Ignoring unsupported target "' .. target_value ..
+            '" for badge key "' .. str.stringify(badge_config['key']) ..
+            '". Allowed: _self, _blank, _parent, _top.'
+          )
+        end
+      end
+
+      inner_html = '<a ' .. anchor_attrs .. '>' .. inner_html .. '</a>'
+    end
+  end
+
+  -- Optional inline background-colour style.
+  local style_attr = ''
+  local colour_value = badge_config['colour'] or badge_config['color']
+  if not str.is_empty(colour_value) then
+    local colour_string = str.stringify(colour_value)
+    if is_valid_colour(colour_string) then
+      style_attr = 'style="background-color: ' ..
+        str.escape_attribute(colour_string) .. ';" '
+    else
+      if not warned_invalid_colours[colour_string] then
+        log.log_warning(
+          EXTENSION_NAME,
+          'Ignoring invalid colour "' .. colour_string ..
+          '" for badge key "' .. str.stringify(badge_config['key']) ..
+          '". Expected a CSS named colour, hex, rgb/rgba, hsl/hsla, or hwb value.'
+        )
+        warned_invalid_colours[colour_string] = true
+      end
+    end
+  end
+
+  -- Optional title tooltip.
+  local title_attr = ''
+  if not str.is_empty(badge_config['title']) then
+    local title_value = str.stringify(badge_config['title'])
+    local resolved_title = substitute_value(title_value, badge_value)
+    title_attr = 'title="' .. str.escape_attribute(resolved_title) .. '" '
+  end
+
+  return '<span class="badge rounded-pill quarto-badge ' ..
+    str.escape_attribute(css_class) .. '" ' ..
+    style_attr ..
+    title_attr ..
+    '>' ..
+    inner_html ..
+    '</span>'
+end
+
 --- Badge shortcode handler.
 --- Generates styled badge elements from document metadata configuration.
---- Badges are defined in document metadata with key, class, colour, and href properties.
---- The shortcode renders badges with optional hyperlinks and custom styling.
+--- Badges are defined in document metadata with key, class, colour, icon,
+--- href, target, and title properties.
 ---
 --- @param args table Array of positional arguments (badge key and value)
 --- @param _kwargs table Table of named keyword arguments (unused)
 --- @param meta table Document metadata containing badge definitions
---- @return pandoc.RawInline|nil HTML badge element or nil for non-HTML formats
+--- @return pandoc.RawInline HTML badge element, or an empty inline for non-HTML formats and warning paths
 --- @usage {{< badge key value >}}
 local function badge(args, _kwargs, meta)
   if not quarto.doc.is_format('html') then
-    return nil
+    return pandoc.RawInline('html', '')
   end
 
   quarto.doc.add_html_dependency({
@@ -35,84 +295,41 @@ local function badge(args, _kwargs, meta)
     stylesheets = {'badge.css'}
   })
 
-  --- @type string Badge key from metadata
-  local badgeKey = str.stringify(args[1])
-  --- @type string Badge value/content to display
-  local badgeValue = str.stringify(args[2])
+  --- @type string Requested badge key
+  local badge_key = str.stringify(args[1])
+  --- @type string Badge value to display
+  local badge_value = str.stringify(args[2])
 
-  -- Get badge configurations from metadata (prefer scoped extensions.badge)
-  --- @type table|nil Array of badge configurations
-  local badge_configs
-  if meta_mod.get_extension_config(meta, EXTENSION_NAME) then
-    badge_configs = meta_mod.get_extension_config(meta, EXTENSION_NAME)
-  else
-    -- Check deprecated top-level structure
-    badge_configs, deprecation_warning_shown = meta_mod.check_deprecated_config(
-      meta,
-      EXTENSION_NAME,
-      nil,  -- nil key indicates we want the entire extension config (array)
-      deprecation_warning_shown
-    )
+  if str.is_empty(badge_key) then
+    log.log_warning(EXTENSION_NAME, 'Badge shortcode requires a key as the first argument.')
+    return pandoc.RawInline('html', '')
   end
+
+  local base_badges = load_base_badges(meta)
+  local badge_configs = apply_overrides(base_badges, meta)
 
   if pdoc.is_object_empty(badge_configs) then
-    return nil
+    log.log_warning(
+      EXTENSION_NAME,
+      'No badge configuration found. Define badges under "extensions.badge" in document or project metadata.'
+    )
+    return pandoc.RawInline('html', '')
   end
 
-  --- @type string HTML content for the badge
-  local badgeContent = ''
-
-  for _, badge_config in ipairs(badge_configs) do
-    --- @type string Badge key from metadata entry
-    local metaBadgeKey = str.stringify(badge_config['key'])
-
-    if metaBadgeKey == badgeKey then
-      --- @type string CSS class for the badge
-      local metaBadgeClass = ''
-      if not str.is_empty(badge_config['class']) then
-        metaBadgeClass = str.stringify(badge_config['class'])
-      end
-
-      --- @type string Badge value (potentially wrapped in link)
-      local displayValue = badgeValue
-
-      -- Process optional href (hyperlink)
-      if not str.is_empty(badge_config['href']) then
-        --- @type string Hyperlink URL for the badge
-        local metaBadgeHref = str.stringify(badge_config['href'])
-        -- Replace {{value}} placeholder with actual badge value
-        if metaBadgeHref:find('{{value}}') then
-          metaBadgeHref = metaBadgeHref:gsub('{{value}}', badgeValue)
-        end
-        displayValue = '<a ' ..
-          'href="' .. metaBadgeHref .. '" ' ..
-          'class="quarto-badge-href"' ..
-          '>' ..
-          badgeValue ..
-          '</a>'
-      end
-
-      -- Process optional colour/color
-      --- @type string Custom style attribute for badge colour
-      local style = ''
-      local colour = badge_config['colour'] or badge_config['color']
-      if not str.is_empty(colour) then
-        local metaBadgeColour = str.stringify(colour)
-        style = 'style="background-color: ' .. metaBadgeColour .. ';" '
-      end
-
-      badgeContent = '<span class="badge rounded-pill quarto-badge ' ..
-        metaBadgeClass .. '" ' ..
-        style ..
-        '>' ..
-        displayValue ..
-        '</span>'
-
-      break
+  local match = find_badge_config(badge_configs, badge_key)
+  if match == nil then
+    if not warned_unknown_keys[badge_key] then
+      log.log_warning(
+        EXTENSION_NAME,
+        'No badge configuration matches key "' .. badge_key ..
+        '". Add an entry with this key under "extensions.badge".'
+      )
+      warned_unknown_keys[badge_key] = true
     end
+    return pandoc.RawInline('html', '')
   end
 
-  return pandoc.RawInline('html', badgeContent)
+  return pandoc.RawInline('html', build_badge_html(match, badge_value))
 end
 
 --- Module export table.

--- a/example.qmd
+++ b/example.qmd
@@ -52,7 +52,7 @@ Badges can be used to highlight version information, feature status, or any cate
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-badge
+quarto add mcanouil/quarto-badge@2.4.1
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/example.qmd
+++ b/example.qmd
@@ -26,6 +26,22 @@ extensions:
       colour: "#ffc107"
     - key: experimental
       class: bg-info
+    - key: download
+      colour: dodgerblue
+      icon: download
+      href: https://github.com/mcanouil/quarto-badge/releases/tag/{{value}}
+      target: _blank
+      title: "Download release {{value}} in a new tab"
+    - key: release-note
+      colour: gold
+      title: "Notes for release {{value}}"
+badge-overrides:
+  - key: experimental
+    colour: hotpink
+    class: ""
+  - key: doc-only
+    colour: teal
+    icon: stars
 ---
 
 ## Introduction
@@ -36,7 +52,7 @@ Badges can be used to highlight version information, feature status, or any cate
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-badge@2.4.1
+quarto add mcanouil/quarto-badge
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -45,12 +61,12 @@ If you're using version control, you will want to check in this directory.
 
 ## Usage
 
-The shortcode `{{< badge <key> <value> >}}` displays a badge with the specified key and value.
+The shortcode `{{{< badge <key> <value> >}}}` displays a badge with the specified key and value.
 
 ```markdown
-{{< badge current 1.0.0 >}}
-{{< badge future 2.0.0 >}}
-{{< badge old 0.1.0 >}}
+{{{< badge current 1.0.0 >}}}
+{{{< badge future 2.0.0 >}}}
+{{{< badge old 0.1.0 >}}}
 ```
 
 ## Configuration
@@ -63,8 +79,17 @@ Each badge configuration supports the following properties:
 
 - **`key`** (required): The identifier used in the shortcode to reference this badge configuration.
 - **`colour`** or **`color`** (optional): A CSS colour value (e.g., `firebrick`, `#ff0000`, `rgb(255, 0, 0)`).
+  Invalid values are reported via a warning and ignored.
 - **`class`** (optional): CSS class(es) to apply to the badge (e.g., Bootstrap classes like `bg-danger`, `bg-warning`).
-- **`href`** (optional): URL to link the badge to. Use `{{value}}` as a placeholder to insert the badge value into the URL.
+- **`href`** (optional): URL to link the badge to.
+  Use `{{value}}` as a placeholder to insert the badge value into the URL.
+  Disallowed schemes (such as `javascript:`) are reported via a warning and ignored.
+- **`target`** (optional): Link target attribute.
+  Allowed values are `_self`, `_blank`, `_parent`, and `_top`.
+  When set to `_blank` the link automatically receives `rel="noopener noreferrer"`.
+- **`title`** (optional): Tooltip text shown on hover.
+  The `{{value}}` placeholder is also supported.
+- **`icon`** (optional): Bootstrap icon name (without the `bi-` prefix) shown before the value.
 
 ### Example Configuration
 
@@ -87,6 +112,30 @@ extensions:
       colour: "#ffc107"
     - key: experimental
       class: bg-info
+    - key: download
+      colour: dodgerblue
+      icon: download
+      href: https://github.com/mcanouil/quarto-badge/releases/tag/{{value}}
+      target: _blank
+      title: "Download release {{value}} in a new tab"
+    - key: release-note
+      colour: gold
+      title: "Notes for release {{value}}"
+```
+
+### Document-Level Overrides
+
+Project-level badges defined in `_quarto.yml` can be overridden in a single document via the `badge-overrides` key.
+Entries are matched by `key`; matching keys are replaced and new keys are appended.
+
+```yaml
+badge-overrides:
+  - key: experimental
+    colour: hotpink
+    class: ""
+  - key: doc-only
+    colour: teal
+    icon: stars
 ```
 
 ## Basic Badge Usage
@@ -137,7 +186,7 @@ Badges can use direct colour values:
 
 Badges can use Bootstrap classes for styling:
 
-- `{{{< badge experimental alpha >}}}` renders as {{< badge experimental alpha >}} (using `bg-info` class).
+- `{{{< badge experimental alpha >}}}` renders as {{< badge experimental alpha >}} (overridden to a hot pink background by the document overrides).
 - `{{{< badge future next >}}}` renders as {{< badge future next >}} (using `bg-danger` class).
 
 ### Linked Badges
@@ -146,6 +195,15 @@ Badges can include hyperlinks using the `href` configuration option:
 
 - `{{{< badge deprecated 1.0 >}}}` renders as {{< badge deprecated 1.0 >}} (links to GitHub releases).
 - `{{{< badge future 2.0 >}}}` renders as {{< badge future 2.0 >}} (links to repository).
+
+### Icons, Tooltips, and Link Targets
+
+- `{{{< badge download v2.5.0 >}}}` renders as {{< badge download v2.5.0 >}}, combining an icon prefix, a link, a `_blank` target, and a tooltip.
+- `{{{< badge release-note v2.5.0 >}}}` renders as {{< badge release-note v2.5.0 >}} with a hover tooltip.
+
+### Document-Level Override
+
+- `{{{< badge doc-only beta >}}}` renders as {{< badge doc-only beta >}} (defined only via `badge-overrides`).
 
 ## Multiple Badge Types
 


### PR DESCRIPTION
Addresses the review findings for `quarto-badge` (v2.4.1 to v2.5.0).

The unknown-key path no longer renders an empty inline silently.
All values flowing into attributes are now HTML-escaped, closing the attribute-injection issue when `{{value}}` is substituted into `href`.
Colour and URL inputs are validated and rejected with a warning rather than emitted verbatim.

The configuration surface gains four optional fields (`icon`, `target`, `title`, plus a per-document `badge-overrides` table) and the shared `_modules` directory is resynchronised with the canonical source.

- fix: Emit `quarto.log.warning` when the shortcode is invoked with a key that is not declared in metadata, instead of silently returning an empty inline.
- fix: HTML-escape badge value, `href` (including after `{{value}}` substitution), `class`, and `title` attributes to prevent attribute injection from quoted values or HTML specials.
- feat: Add `icon` configuration option for a Bootstrap icon prefix.
- feat: Add `target` configuration option with `_self`/`_blank`/`_parent`/`_top` values; `_blank` automatically receives `rel="noopener noreferrer"`.
- feat: Add `title` configuration option with `{{value}}` placeholder support for hover tooltips.
- feat: Validate `colour` values against CSS named colours, hex, `rgb`/`rgba`, `hsl`/`hsla`, `hwb`, `lab`, `lch`, `oklab`, `oklch`, and `color()` forms; invalid values are warned and ignored.
- feat: Validate `href` after `{{value}}` substitution; whitespace, control characters, and disallowed schemes (such as `javascript:`) are warned and the anchor is omitted.
- feat: Support per-document `badge-overrides` metadata key that overrides matching project-level entries by `key` and appends new keys.
- refactor: Resynchronise `string.lua`, `logging.lua`, `metadata.lua`, and `pandoc-helpers.lua` with the canonical source under `creating-quarto-extension/assets/modules`; add `colour.lua` for named-colour validation.
- docs: Document all new options, the validation behaviour, and the override semantics in `README.md`, `example.qmd`, and `_schema.yml`.
- docs: Bump `_extension.yml` version to `2.5.0` and add a `2.5.0 (2026-05-28)` entry in `CHANGELOG.md`.
