### PR TITLE
refactor: Target Quarto Wizard v2 extension schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Refactoring
+
+- refactor: Target the Quarto Wizard v2 extension schema in `_schema.yml`, renaming `min-items` to `minItems`.
+
 ## 2.5.1 (2026-08-01)
 
 ### Documentation

--- a/_extensions/badge/_schema.yml
+++ b/_extensions/badge/_schema.yml
@@ -1,11 +1,11 @@
 # Schema for the badge extension
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   badge:
     type: array
-    min-items: 1
+    minItems: 1
     description: "Array of badge configuration objects."
     items:
       type: object
@@ -43,7 +43,7 @@ options:
           description: "Optional Bootstrap icon name (without the 'bi-' prefix) prepended before the badge value."
   badge-overrides:
     type: array
-    min-items: 1
+    minItems: 1
     description: "Document-level overrides for badge configurations defined at project level. Entries are matched by 'key'; matching keys are replaced, new keys are appended."
     items:
       type: object


### PR DESCRIPTION
Points `_schema.yml` at the Quarto Wizard v2 meta-schema and renames `min-items` to `minItems`. v2 uses JSON Schema 2020-12 canonical names exclusively, so the v1 spelling no longer validates and editors ignored the bound on `badge` and `badge-overrides`.