### PR TITLE
fix: guard the badge shortcode against missing arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: The `badge` shortcode no longer stops the render when it is called with no arguments. It reports the missing key and renders nothing. (#49)
+
 ## 2.6.0 (2026-09-07)
 
 ### New Features

--- a/_extensions/badge/badge.lua
+++ b/_extensions/badge/badge.lua
@@ -315,9 +315,9 @@ local function badge(args, kwargs, meta)
   })
 
   --- @type string Requested badge key
-  local badge_key = str.stringify(args[1])
+  local badge_key = #args > 0 and str.stringify(args[1]) or ''
   --- @type string Badge value to display
-  local badge_value = str.stringify(args[2])
+  local badge_value = #args > 1 and str.stringify(args[2]) or ''
 
   if str.is_empty(badge_key) then
     log.log_warning(EXTENSION_NAME, 'Badge shortcode requires a key as the first argument.')


### PR DESCRIPTION
Calling the shortcode with no arguments stopped the whole render with `Cannot get Attr from TypeNil`. It now reports the missing key and renders nothing.